### PR TITLE
Add pytest coverage for red-black BST operations

### DIFF
--- a/BST.py
+++ b/BST.py
@@ -80,14 +80,20 @@ class RedBlackBST():
         else: 
             h.val = val
         
+        # Lean left: any red link on the right violates the left-leaning
+        # invariant, so rotate it to the left side before continuing.
         if self.isRed(h.right) and (not self.isRed(h.left)):
             h= self.rotateLeft(h)
             if h == None:
                 print(h)
+        # Balance a temporary 4-node formed by two consecutive left red links
+        # by rotating right. This restores perfect black balance.
         if self.isRed(h.left) and self.isRed(h.left.left):
             h= self.rotateRight(h)
             if h == None:
                 print(h)
+        # Split 4-nodes: both children red means we need to flip colors so the
+        # parent becomes red and the children black, preserving invariants.
         if self.isRed(h.left) and self.isRed(h.right):
             self.flipColors(h)
             if h == None:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Python Sorting Algorithms
 
-This project provides Python implementations of several common sorting algorithms within the `Sorting.py` file. These implementations are primarily intended for educational and demonstrational purposes, allowing users to study and compare the behavior of different sorting techniques.
+This project provides Python implementations of several common sorting algorithms within the `Sorting.py` file.
+These implementations are primarily intended for educational and demonstrational purposes, allowing users to study and compare the behavior of different sorting techniques.
 
 ## Helper Functions
 

--- a/tests/test_red_black_bst.py
+++ b/tests/test_red_black_bst.py
@@ -1,0 +1,47 @@
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from BST import RedBlackBST
+
+
+def build_sample_tree():
+    tree = RedBlackBST()
+    entries = [
+        ("t", 10),
+        ("d", 30),
+        ("c", 40),
+        ("a", 11),
+        ("e", 22),
+        ("f", 3),
+    ]
+    for key, value in entries:
+        tree.put_main(key, value)
+    return tree
+
+
+def test_get_returns_inserted_values():
+    tree = build_sample_tree()
+
+    assert tree.get_main("t") == 10
+    assert tree.get_main("d") == 30
+    assert tree.get_main("f") == 3
+    assert tree.get_main("missing") is None
+
+
+def test_updating_existing_key_does_not_change_size():
+    tree = RedBlackBST()
+    tree.put_main("k", 1)
+    tree.put_main("a", 2)
+
+    original_size = tree.size(tree.root)
+
+    tree.put_main("k", 99)
+
+    assert tree.get_main("k") == 99
+    assert tree.size(tree.root) == original_size


### PR DESCRIPTION
## Summary
- add a pytest test module that exercises red-black BST inserts and lookups
- verify updating an existing key returns the new value without inflating the stored size

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d535e170008326a632c4b54fa7da3c