### PR TITLE
Add breadth-first search implementation and tests

### DIFF
--- a/BST.py
+++ b/BST.py
@@ -80,14 +80,20 @@ class RedBlackBST():
         else: 
             h.val = val
         
+        # Lean left: any red link on the right violates the left-leaning
+        # invariant, so rotate it to the left side before continuing.
         if self.isRed(h.right) and (not self.isRed(h.left)):
             h= self.rotateLeft(h)
             if h == None:
                 print(h)
+        # Balance a temporary 4-node formed by two consecutive left red links
+        # by rotating right. This restores perfect black balance.
         if self.isRed(h.left) and self.isRed(h.left.left):
             h= self.rotateRight(h)
             if h == None:
                 print(h)
+        # Split 4-nodes: both children red means we need to flip colors so the
+        # parent becomes red and the children black, preserving invariants.
         if self.isRed(h.left) and self.isRed(h.right):
             self.flipColors(h)
             if h == None:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Python Sorting Algorithms
 
-This project provides Python implementations of several common sorting algorithms within the `Sorting.py` file. These implementations are primarily intended for educational and demonstrational purposes, allowing users to study and compare the behavior of different sorting techniques.
+This project provides Python implementations of several common sorting algorithms within the `Sorting.py` file.
+These implementations are primarily intended for educational and demonstrational purposes, allowing users to study and compare the behavior of different sorting techniques.
 
 ## Helper Functions
 

--- a/graph_search.py
+++ b/graph_search.py
@@ -1,0 +1,150 @@
+"""Graph search utilities.
+
+This module currently exposes a tiny adjacency-list graph container and a
+recursive depth-first search (DFS) implementation.  The goal is to provide a
+straightforward, well-documented reference implementation that can be reused in
+tests or experiments across the repository.
+
+Example
+-------
+>>> graph = Graph()
+>>> graph.add_edge("A", "B")
+>>> graph.add_edge("A", "C")
+>>> graph.add_edge("B", "D")
+>>> depth_first_search(graph, "A")
+['A', 'B', 'D', 'C']
+
+The DFS traversal visits each vertex exactly once, following outgoing edges in
+the order they were added.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from typing import Deque, Dict, Iterable, List, Set, TypeVar
+
+T = TypeVar("T")
+
+
+class Graph:
+    """A lightweight adjacency-list representation of a graph.
+
+    The graph is undirected by default.  When adding an edge, callers can opt
+    into directed semantics by passing ``directed=True``.
+    """
+
+    def __init__(self) -> None:
+        self._adj: Dict[T, List[T]] = defaultdict(list)
+
+    def add_vertex(self, vertex: T) -> None:
+        """Ensure ``vertex`` is present in the adjacency map."""
+
+        self._adj.setdefault(vertex, [])
+
+    def add_edge(self, u: T, v: T, *, directed: bool = False) -> None:
+        """Add an edge between ``u`` and ``v``.
+
+        Parameters
+        ----------
+        u, v:
+            Endpoints of the edge.
+        directed:
+            If ``True`` only the ``u`` -> ``v`` direction is recorded.  When
+            ``False`` (the default) the opposite direction ``v`` -> ``u`` is
+            also inserted so the graph behaves as undirected.
+        """
+
+        self._adj[u].append(v)
+        if not directed:
+            self._adj[v].append(u)
+        else:
+            self._adj.setdefault(v, [])
+
+    def neighbors(self, vertex: T) -> Iterable[T]:
+        """Return the adjacent vertices for ``vertex``.
+
+        The returned iterable reflects the order in which neighbors were added
+        to the graph.
+        """
+
+        return tuple(self._adj[vertex])
+
+    def __contains__(self, vertex: object) -> bool:
+        return vertex in self._adj
+
+
+def depth_first_search(graph: Graph, start: T) -> List[T]:
+    """Perform a depth-first search starting at ``start``.
+
+    Parameters
+    ----------
+    graph:
+        A :class:`Graph` instance describing the search space.
+    start:
+        The starting vertex.  ``KeyError`` is raised if the vertex is not part
+        of the graph.
+
+    Returns
+    -------
+    list
+        The vertices in the order they were first discovered during the DFS.
+    """
+
+    if start not in graph:
+        raise KeyError(f"Start vertex {start!r} not present in graph")
+
+    visited: Set[T] = set()
+    traversal: List[T] = []
+
+    def dfs(vertex: T) -> None:
+        visited.add(vertex)
+        traversal.append(vertex)
+
+        for neighbor in graph.neighbors(vertex):
+            if neighbor not in visited:
+                dfs(neighbor)
+
+    dfs(start)
+    return traversal
+
+
+def breadth_first_search(graph: Graph, start: T) -> List[T]:
+    """Perform a breadth-first search starting at ``start``.
+
+    The algorithm explores the graph in *layers*.  All neighbors at distance 1
+    from ``start`` are visited before moving on to distance 2, and so on.  This
+    behavior makes BFS useful for computing shortest paths in unweighted graphs
+    and for level-order traversals of tree structures.
+
+    Parameters
+    ----------
+    graph:
+        A :class:`Graph` instance describing the search space.
+    start:
+        The starting vertex.  ``KeyError`` is raised if the vertex is not part
+        of the graph.
+
+    Returns
+    -------
+    list
+        The vertices in the order they were first discovered during the BFS.
+    """
+
+    if start not in graph:
+        raise KeyError(f"Start vertex {start!r} not present in graph")
+
+    visited: Set[T] = {start}
+    traversal: List[T] = []
+    queue: Deque[T] = deque([start])
+
+    while queue:
+        vertex = queue.popleft()
+        traversal.append(vertex)
+
+        for neighbor in graph.neighbors(vertex):
+            if neighbor not in visited:
+                visited.add(neighbor)
+                queue.append(neighbor)
+
+    return traversal
+

--- a/tests/test_breadth_first_search.py
+++ b/tests/test_breadth_first_search.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from graph_search import Graph, breadth_first_search
+
+
+def test_breadth_first_search_traversal_order():
+    graph = Graph()
+    graph.add_edge("A", "B")
+    graph.add_edge("A", "C")
+    graph.add_edge("B", "D")
+    graph.add_edge("C", "E")
+
+    assert breadth_first_search(graph, "A") == ["A", "B", "C", "D", "E"]
+
+
+def test_breadth_first_search_handles_directed_edges():
+    graph = Graph()
+    graph.add_edge(1, 2, directed=True)
+    graph.add_edge(2, 3, directed=True)
+    graph.add_vertex(4)
+
+    assert breadth_first_search(graph, 1) == [1, 2, 3]
+
+
+def test_breadth_first_search_missing_start_vertex():
+    graph = Graph()
+    graph.add_vertex("existing")
+
+    with pytest.raises(KeyError):
+        breadth_first_search(graph, "missing")

--- a/tests/test_depth_first_search.py
+++ b/tests/test_depth_first_search.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from graph_search import Graph, depth_first_search
+
+
+def test_depth_first_search_traversal_order():
+    graph = Graph()
+    graph.add_edge("A", "B")
+    graph.add_edge("A", "C")
+    graph.add_edge("B", "D")
+    graph.add_edge("C", "E")
+
+    assert depth_first_search(graph, "A") == ["A", "B", "D", "C", "E"]
+
+
+def test_depth_first_search_handles_directed_edges():
+    graph = Graph()
+    graph.add_edge(1, 2, directed=True)
+    graph.add_edge(2, 3, directed=True)
+    graph.add_vertex(4)
+
+    assert depth_first_search(graph, 1) == [1, 2, 3]
+
+
+def test_depth_first_search_missing_start_vertex():
+    graph = Graph()
+    graph.add_vertex("existing")
+
+    with pytest.raises(KeyError):
+        depth_first_search(graph, "missing")
+

--- a/tests/test_red_black_bst.py
+++ b/tests/test_red_black_bst.py
@@ -1,0 +1,47 @@
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from BST import RedBlackBST
+
+
+def build_sample_tree():
+    tree = RedBlackBST()
+    entries = [
+        ("t", 10),
+        ("d", 30),
+        ("c", 40),
+        ("a", 11),
+        ("e", 22),
+        ("f", 3),
+    ]
+    for key, value in entries:
+        tree.put_main(key, value)
+    return tree
+
+
+def test_get_returns_inserted_values():
+    tree = build_sample_tree()
+
+    assert tree.get_main("t") == 10
+    assert tree.get_main("d") == 30
+    assert tree.get_main("f") == 3
+    assert tree.get_main("missing") is None
+
+
+def test_updating_existing_key_does_not_change_size():
+    tree = RedBlackBST()
+    tree.put_main("k", 1)
+    tree.put_main("a", 2)
+
+    original_size = tree.size(tree.root)
+
+    tree.put_main("k", 99)
+
+    assert tree.get_main("k") == 99
+    assert tree.size(tree.root) == original_size


### PR DESCRIPTION
## Summary
- extend the reusable graph search helpers with a queue-based breadth-first traversal
- cover the new breadth-first search with tests for traversal order, directed edges, and invalid starts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d535e170008326a632c4b54fa7da3c